### PR TITLE
Fixing the behavior of clicking on panels on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,11 +63,10 @@
 			left: 0;
 			padding: var(--gap);
 			height: 100%;
-			/*display: none;*/
+			display: none;
 			overflow: hidden;
 			color: white;
 			transition: all .5s ease;
-			opacity: 0;		
 		}
         .info h2 {
             font-size:2rem;
@@ -89,11 +88,27 @@
 			text-decoration: none;
             font-size: 1.5rem;
 		}
+
+		@keyframes fadeInFromNone {
+		    0% {
+		        display: none;
+		        opacity: 0;
+		    }
+
+		    1% {
+		        display: block;
+		        opacity: 0;
+		    }
+
+		    100% {
+		        display: block;
+		        opacity: 1;
+		    }
+		}
 		.visible {
 			display: block;
 			background-color: var(--off-black);
-			opacity: 0.75;
-			transition: all .5s ease;
+			animation: fadeInFromNone 0.5s ease;
 		}
 
 		body {
@@ -176,7 +191,9 @@
 				text-decoration: none;
 			}
 			.visible {
+				display: block;
 				opacity: 0.95;
+				z-index: 1000;
 			}
 		}
 	</style>


### PR DESCRIPTION
Turns out I don't think it was the loop closure issue at all! I think it's simply that with `opacity: 0`, your [last] `.info` element is intercepting the click. In this pull request, I added an example of using `keyframes` to animate from `display: none`, drawn from [here](https://stackoverflow.com/a/17191375).